### PR TITLE
feat: add /echo and /info endpoints, add OpenAPI spec, and update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.0 - 2024-12-10
+- Added `/echo` endpoint for echoing and modifying messages
+- Added `/info` endpoint for returning environment-based metadata
+- Introduced environment variables (SERVICE_ENV, LOG_VERBOSITY, FAKE_SECRET, VERSION, GIT_COMMIT) for runtime configuration
+- Added corresponding tests and updated documentation examples
+- Create OpenAPI Specification within openapi.yaml
+- Improved documentation in README.md
+
 ## v0.1.0 - 2024-12-10
 - Initial release of toy-service with:
   - /healthz endpoint

--- a/README.md
+++ b/README.md
@@ -1,40 +1,195 @@
 # Toy Service
 
-This is a minimal toy microservice written in Go to demonstrate an incremental approach to building a well-structured, cloud-native application. It will eventually showcase:
+Welcome to `toy-service`, a minimal microservice in Go designed to demonstrate best practices in open-source software development, including OpenAPI-driven design, Semantic Versioning, GitOps deployments, and more. As we evolve this service, we’ll illustrate how to incrementally adopt industry-standard tools and workflows to ensure a clear API contract, smooth contributor experience, and reliable CI/CD.
 
-- OpenAPI-defined endpoints
-- Semantic versioning integration
-- Automated CI/CD with Tekton or GitHub Actions
-- GitOps deployment via Argo CD
-- Environmental configuration and mocking strategies
-- Documentation and contributor guidelines
+## Key Features and Goals
+
+- **OpenAPI-defined endpoints:**
+  The API contract is defined via an [OpenAPI Specification](https://www.openapis.org/). This ensures clarity and consistency for contributors and integrators, allowing automatic client code generation, documentation, and validation.
+
+- **Semantic Versioning (SemVer) Integration:**
+  Using [Semantic Versioning](https://semver.org/) makes it clear when changes are backward-compatible, introduce new features, or are breaking. This is crucial for multi-service ecosystems where external consumers depend on stable API contracts.
+
+- **Automated CI/CD with Tekton or GitHub Actions (planned):**
+  Future steps will introduce continuous integration and delivery pipelines, ensuring every commit and pull request is tested, built, and (optionally) deployed automatically.
+
+- **GitOps Deployment with Argo CD (planned):**
+  By using Git as the single source of truth for environment configurations and deployments, we’ll enable near-instant feedback loops for contributors and ensure reliable, versioned rollouts.
+
+- **Environment Configuration & Mocking Strategies:**
+  Contributors can easily adjust environment variables to test different configurations locally or in dev environments, without needing complex local setups.
+
+- **Contributor Guidelines and Documentation:**
+  We’ll provide clear instructions for setting up development environments, writing tests, following versioning policies, and making good pull requests.
 
 ## Project Structure
 
-The following structure separates the main application entry point (cmd/server/main.go) from internal logic (internal/handlers), making it easier to scale and test. Tests reside in a tests directory. As the service grows, we can add more packages and directories.
+The code is structured to separate concerns and maintain clarity:
 
 ```
 toy-service/
-├─ cmd/
-│  └─ server/
-│     └─ main.go          # main entry point
-├─ internal/
-│  └─ handlers/
-│     └─ healthz.go       # handler for /healthz endpoint
-│     └─ healthz_test.go  # unit tests for healthz handler
-├─ go.mod
-├─ go.sum
-├─ Dockerfile
-├─ Makefile
-└─ README.md
+├── CHANGELOG.md
+├── Dockerfile
+├── Makefile
+├── README.md
+├── go.mod
+├── go.sum
+├── cmd/
+│   └── server/
+│       └── main.go # Entry point for the service
+├── internal/
+│   └── handlers/  # Handlers for each endpoint
+│       ├── echo.go
+│       ├── echo_test.go
+│       ├── env.go
+│       ├── healthz.go
+│       ├── healthz_test.go
+│       ├── info.go
+│       └── info_test.go
+└── spec/
+    └── openapi.yaml # OpenAPI specification for this service
 ```
-
-## Current Status
-
-Currently, the service only has a `/healthz` endpoint for verifying basic functionality. Future steps will add `/echo`, `/info`, and the full pipeline.
 
 ## Running Locally
 
-```bash
+Before running, ensure you have Go 1.20+ installed and Docker (optional for containerization).
+
+```shell
 make build
 make run
+```
+
+This will start the service on http://localhost:8080. Current endpoints:
+
+- `GET /healthz`: Basic health check, returns `{ "status": "ok" }`.
+- `POST /echo`: Accepts `{ "message": "Hello" }` and returns `{ "message": "Hello [modified]", "version": "...", "commit": "...", "env": "..." }`.
+- `GET /info`: Returns metadata about the service, including environment (env), version (version), log verbosity (logVerbosity), fake secret (fakeSecret), and current commit hash (commit).
+
+## Environment Variables
+
+You can influence runtime behavior and metadata via environment variables:
+
+- `SERVICE_ENV` (e.g., dev, prod)
+- `LOG_VERBOSITY` (e.g., info, debug)
+- `FAKE_SECRET` (e.g., redacted, topsecret)
+- `VERSION` (e.g., v0.2.0)
+- `GIT_COMMIT` (e.g., abc1234)
+
+For example:
+
+```shell
+export SERVICE_ENV=prod
+export LOG_VERBOSITY=debug
+export FAKE_SECRET=topsecret
+export VERSION=v0.2.0
+export GIT_COMMIT=abc1234
+
+make run
+```
+
+## Example Usage
+
+```shell
+curl http://localhost:8080/healthz
+# {"status":"ok"}
+
+curl -X POST -H "Content-Type: application/json" -d '{"message":"Hello"}' http://localhost:8080/echo
+# {"message":"Hello [modified]","version":"v0.2.0","commit":"unknown","env":"dev"}
+
+curl http://localhost:8080/info
+# {"name":"toy-service","version":"v0.2.0","env":"dev","logVerbosity":"info","fakeSecret":"redacted","commit":"unknown"}
+```
+
+(Adjust your environment variables to see different responses.)
+
+## Development Workflow
+
+### Branching Strategy
+
+#### Main Branch:
+The main branch is the trunk of development. It should always be in a working state, tested, and ready for release.
+
+#### Feature Branches:
+Create a new branch (`feature/your-feature-name`) for each new feature, bug fix, or documentation improvement. Work on your changes there, then open a Pull Request (PR) against `main`.
+
+### Pull Requests & Reviews:
+When you open a PR, automated tests (and later CI/CD pipelines) run. Once everything passes and at least one reviewer approves, we merge it into `main`.
+
+## Semantic Versioning (SemVer)
+
+We follow SemVer rules:
+
+- **MAJOR (X.0.0):** Incompatible API changes.
+- **MINOR (0.X.0):** Backwards-compatible feature additions.
+- **PATCH (0.0.X):** Backwards-compatible bug fixes.
+
+### Workflow for SemVer & Releases:
+
+#### Commit Messages & Conventional Commits (Optional but Recommended):
+Use commit prefixes like `feat:`, `fix:`, `docs:`, `chore:`, etc. This helps automated tools infer whether to bump MAJOR, MINOR, or PATCH versions.
+
+Example:
+
+- `feat: add /echo endpoint` → MINOR bump
+- `fix: correct error handling in /info` → PATCH bump
+- `feat!: remove old endpoint (with !)` → MAJOR bump (breaking change)
+
+Check out [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more details.
+
+#### Tagging Releases:
+Once changes are merged to `main` and you’re ready to release, create a Git tag like `v0.2.0`. This tag represents a snapshot of the code at release time. CI/CD (once integrated) can build and push corresponding Docker images and update GitOps manifests.
+
+For early development, you might manually assign versions. Later, you can automate versioning using tools like semantic-release.
+
+#### Updating the CHANGELOG:
+Every time you cut a release, update `CHANGELOG.md` to summarize what changed. The CHANGELOG entry is user-facing: just the highlights of what changed and what’s new in the release. For example:
+
+```md
+## v0.2.0 - YYYY-MM-DD
+- Added /echo endpoint
+- Added /info endpoint
+- Introduced environment variables for configuration
+```
+
+This helps contributors and users know what’s new, what’s fixed, and when breaking changes occur.
+
+## Integrating OpenAPI Changes
+
+When you add or modify an endpoint:
+
+- Update the `spec/openapi.yaml` file so the specification remains the single source of truth for API behavior.
+- Confirm that your changes align with SemVer. Adding a new endpoint in a backward-compatible manner is a MINOR release. Removing or changing an existing endpoint’s contract in a backward-incompatible way requires a MAJOR release bump.
+
+## Future Enhancements
+
+- **CI/CD Pipelines:**
+  We will introduce Tekton or GitHub Actions workflows that run tests, verify code coverage, lint code, and build Docker images automatically on every PR and push.
+
+- **GitOps with Argo CD:**
+  In a future iteration, you’ll see a separate Git repository managing Kubernetes manifests for toy-service. Argo CD will continuously reconcile the cluster state with the declared manifests, automatically deploying new versions as they appear.
+
+- **Pre-Release Tags:**
+  For testing in dev environments, you may use pre-release tags (`v0.2.0-alpha.1`) to indicate that this is a work-in-progress or experimental build. Contributors can test against these pre-releases before stable versions are cut.
+
+## Contributing
+
+1. Fork and Clone this repository.
+2. Create a Feature Branch:
+
+```shell
+git checkout -b feature/my-new-endpoint
+```
+
+3. Implement and Test:
+   Add or modify handlers, update `openapi.yaml`, run `make test`.
+
+4. Open a Pull Request:
+   Once done, push your branch and open a PR against `main`.
+
+5. Code Review & Merge:
+   After tests pass and review is complete, changes are merged. If necessary, we tag and release a new version.
+
+## License
+
+This project is free and open source.
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,6 @@
 //
 // The main entrypoint for the toy microservice server.
 // This file sets up the HTTP server, routes, and logging.
-//
-// Initially, it only provides a /healthz endpoint for basic health checks.
-// Future steps will add echo, info endpoints, environment variable handling,
-// semantic versioning integration, and more.
 
 package main
 
@@ -25,8 +21,6 @@ import (
 )
 
 func main() {
-	// Set up structured logging with zerolog
-	// Adjust time format for readability
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	log.Info().Msg("Starting toy-service server")
 
@@ -34,7 +28,14 @@ func main() {
 
 	// Register routes
 	r.Get("/healthz", handlers.HealthzHandler)
+	r.Post("/echo", handlers.EchoHandler)
+	r.Get("/info", handlers.InfoHandler)
 
+	srv := startServer(r)
+	gracefulShutdown(srv)
+}
+
+func startServer(r *chi.Mux) *http.Server {
 	srv := &http.Server{
 		Addr:    ":8080",
 		Handler: r,
@@ -47,7 +48,10 @@ func main() {
 		}
 	}()
 
-	// Graceful shutdown handling
+	return srv
+}
+
+func gracefulShutdown(srv *http.Server) {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 	<-quit

--- a/internal/handlers/echo.go
+++ b/internal/handlers/echo.go
@@ -1,0 +1,56 @@
+// echo.go
+//
+// The echo handler returns the provided message with "[modified]" appended,
+// along with metadata about version, commit, and env.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+type EchoRequest struct {
+	Message string `json:"message"`
+}
+
+type EchoResponse struct {
+	Message string `json:"message"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Env     string `json:"env"`
+}
+
+// EchoHandler handles POST /echo requests.
+// It echoes back the input message, appending " [modified]", and returns
+// version, commit, and environment info.
+func EchoHandler(w http.ResponseWriter, r *http.Request) {
+	log.Debug().Msg("Handling /echo request")
+
+	var req EchoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Error().Err(err).Msg("Failed to decode /echo request body")
+		http.Error(w, `{"error":"Invalid input"}`, http.StatusBadRequest)
+		return
+	}
+
+	cfg := LoadEnvConfig()
+
+	resp := EchoResponse{
+		Message: req.Message + " [modified]",
+		Version: cfg.Version,
+		Commit:  cfg.GitCommit,
+		Env:     cfg.Env,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error().Err(err).Msg("Failed to write /echo response")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Debug().Msg("/echo response successfully returned")
+}

--- a/internal/handlers/echo_test.go
+++ b/internal/handlers/echo_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEchoHandler(t *testing.T) {
+	t.Log("Test that /echo returns a modified message and service metadata")
+
+	r := chi.NewRouter()
+	r.Post("/echo", EchoHandler)
+
+	reqBody := `{"message":"Hello"}`
+	req, err := http.NewRequest("POST", "/echo", bytes.NewBuffer([]byte(reqBody)))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp EchoResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	require.Contains(t, resp.Message, "Hello [modified]")
+	require.NotEmpty(t, resp.Version)
+	require.NotEmpty(t, resp.Commit)
+	require.NotEmpty(t, resp.Env)
+}

--- a/internal/handlers/env.go
+++ b/internal/handlers/env.go
@@ -1,0 +1,40 @@
+// env.go
+//
+// Provides helper functions to retrieve environment variables with defaults.
+
+package handlers
+
+import "os"
+
+// getEnv retrieves the value of the environment variable named by the key,
+// or returns the provided default if the variable is not set.
+func getEnv(key, def string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return def
+	}
+	return val
+}
+
+// EnvConfig holds environment-dependent configuration values.
+type EnvConfig struct {
+	Env          string
+	LogVerbosity string
+	FakeSecret   string
+	Version      string
+	GitCommit    string
+	Name         string
+}
+
+// LoadEnvConfig loads configuration from environment variables.
+// TODO: generate/pull these values in dynamically.
+func LoadEnvConfig() EnvConfig {
+	return EnvConfig{
+		Env:          getEnv("SERVICE_ENV", "dev"),
+		LogVerbosity: getEnv("LOG_VERBOSITY", "info"),
+		FakeSecret:   getEnv("FAKE_SECRET", "redacted"),
+		Version:      getEnv("VERSION", "v0.2.0"),
+		GitCommit:    getEnv("GIT_COMMIT", "unknown"),
+		Name:         "toy-service",
+	}
+}

--- a/internal/handlers/info.go
+++ b/internal/handlers/info.go
@@ -1,0 +1,39 @@
+// info.go
+//
+// The info handler returns service metadata based on environment variables
+// and hardcoded defaults.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+// InfoHandler handles GET /info requests.
+// It returns details about the service configuration and runtime environment.
+func InfoHandler(w http.ResponseWriter, r *http.Request) {
+	log.Debug().Msg("Handling /info request")
+
+	cfg := LoadEnvConfig()
+
+	resp := map[string]string{
+		"name":         cfg.Name,
+		"version":      cfg.Version,
+		"env":          cfg.Env,
+		"logVerbosity": cfg.LogVerbosity,
+		"fakeSecret":   cfg.FakeSecret,
+		"commit":       cfg.GitCommit,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error().Err(err).Msg("Failed to write /info response")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Debug().Msg("/info response successfully returned")
+}

--- a/internal/handlers/info_test.go
+++ b/internal/handlers/info_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoHandler(t *testing.T) {
+	t.Log("Test that /info returns service metadata")
+
+	r := chi.NewRouter()
+	r.Get("/info", InfoHandler)
+
+	req, err := http.NewRequest("GET", "/info", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	require.Equal(t, "toy-service", resp["name"])
+	require.NotEmpty(t, resp["version"])
+	require.NotEmpty(t, resp["env"])
+	require.NotEmpty(t, resp["logVerbosity"])
+	require.NotEmpty(t, resp["fakeSecret"])
+	require.NotEmpty(t, resp["commit"])
+}

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,157 @@
+openapi: 3.0.3
+info:
+  title: Toy Microservice
+  version: 0.2.0
+  description: >
+    A simple toy service that demonstrates echo functionality, version/environment metadata,
+    and health checks. It supports semantic versioning and provides endpoints to retrieve 
+    runtime info and echo input messages with slight modifications.
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+paths:
+  /echo:
+    post:
+      summary: Echo and modify an input message
+      description: |
+        Takes a JSON payload containing a `message` and returns a modified message 
+        along with metadata such as version, commit hash, and environment.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EchoRequest'
+      responses:
+        '200':
+          description: Successful echo response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /info:
+    get:
+      summary: Retrieve service information
+      description: |
+        Returns details about the service including its name, current semantic version, 
+        environment, log verbosity, fake secret value (redacted), and current commit hash.
+      responses:
+        '200':
+          description: Service information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InfoResponse'
+
+  /healthz:
+    get:
+      summary: Health check endpoint
+      description: |
+        Returns a simple status object for readiness/liveness checks.
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+components:
+  schemas:
+    EchoRequest:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Hello world"
+      required:
+        - message
+
+    EchoResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The modified echo message
+          example: "Hello world [modified]"
+        version:
+          type: string
+          description: Current semantic version of the service
+          example: "v0.2.0"
+        commit:
+          type: string
+          description: Git commit hash or short SHA
+          example: "abc1234"
+        env:
+          type: string
+          description: Current runtime environment
+          example: "dev"
+      required:
+        - message
+        - version
+        - commit
+        - env
+
+    InfoResponse:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the service
+          example: "toy-service"
+        version:
+          type: string
+          description: Current semantic version of the service
+          example: "v0.2.0"
+        env:
+          type: string
+          description: Current runtime environment
+          example: "dev"
+        logVerbosity:
+          type: string
+          description: Current log verbosity level
+          example: "info"
+        fakeSecret:
+          type: string
+          description: A placeholder or redacted secret for demonstration
+          example: "redacted"
+        commit:
+          type: string
+          description: Git commit hash
+          example: "abc1234"
+      required:
+        - name
+        - version
+        - env
+        - logVerbosity
+        - fakeSecret
+        - commit
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Health status of the service
+          example: "ok"
+      required:
+        - status
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message explaining what went wrong
+          example: "Invalid input"
+      required:
+        - error


### PR DESCRIPTION
This commit introduces two new endpoints:
- /echo: echoes and modifies a user-provided message, returning version, commit, and environment info.
- /info: returns metadata about the service, including environment configuration, version, verbosity, fake secret, and commit.

Also updated:
- OpenAPI specification (`spec/openapi.yaml`) to reflect these new endpoints and fields.
- Default environment variable values and documentation to align with the new features.
- Improvements to README

This change corresponds to a MINOR version bump as it adds backward-compatible new functionality.